### PR TITLE
Feature - Pass image parameters to InstallService

### DIFF
--- a/service.go
+++ b/service.go
@@ -199,7 +199,7 @@ func InServiceMode() bool {
 	return isIntSess
 }
 
-func InstallService(appPath, name, desc string) error {
+func InstallService(appPath, name, desc string, params ...string) error {
 	m, err := mgr.Connect()
 	if err != nil {
 		return err
@@ -213,7 +213,9 @@ func InstallService(appPath, name, desc string) error {
 	s, err = m.CreateService(name, appPath, mgr.Config{
 		DisplayName: desc,
 		StartType:   windows.SERVICE_AUTO_START,
-	})
+	},
+		params...,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Description: Make InstallService a variadic function to allow passing of image parameters through to (*Mgr).CreateService

Example snippet:

``` go
params := []string{"-config", "C:\\my.conf"}
err := winsvc.InstallService("C:\\svc.exe", "SvcName", "Svc Desc", params...)
```

Since InstallService has been turned into a variadic function, the following call to InstallService still works fine:

``` go
err := winsvc.InstallService("C:\\svc.exe", "SvcName", "Svc Desc")
```
